### PR TITLE
Changed number of win points for korfball

### DIFF
--- a/src/app/lib/ngx-sport/defaultService.ts
+++ b/src/app/lib/ngx-sport/defaultService.ts
@@ -50,6 +50,9 @@ export class DefaultService {
         if (customId === CustomSportId.Chess) {
             return 1;
         }
+        if (customId === CustomSportId.Korfball) {
+            return 2;
+        }
         return 3;
     }
 


### PR DESCRIPTION
The number of win points for korfball is 2. I've changed this in the default service.